### PR TITLE
feat: expose raw fields array and add strictColumns option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,12 @@ export interface CSVStreamOptions {
   totalBytes?: number;
   /** Emit progress events every N rows. Default: 1000. Set to 0 to disable. */
   progressInterval?: number;
+  /**
+   * When true, emits an error if a row has more non-empty columns than headers.
+   * Trailing empty columns are tolerated. Requires headers to be defined.
+   * Defaults to false.
+   */
+  strictColumns?: boolean;
 }
 
 /**
@@ -39,6 +45,10 @@ export interface CSVRowEvent {
   fields: CSVRow;
   /** Raw line string before parsing. */
   raw: string;
+  /** Raw parsed fields as an array of strings before header mapping. */
+  fieldsArray: string[];
+  /** Number of columns in this row (fieldsArray.length). */
+  columnCount: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `fieldsArray` and `columnCount` to `csvrow` events, allowing validation of column counts without re-parsing the raw line
- Add `strictColumns` option that errors on rows with extra non-empty columns while tolerating trailing empty columns

Closes #7

## Changes

### New `csvrow` event properties
```typescript
stream.on('csvrow', (e) => {
  e.detail.fieldsArray  // raw array of strings before header mapping
  e.detail.columnCount  // fieldsArray.length
});
```

### New `strictColumns` option
```typescript
const stream = streamCSV(file, {
  strictColumns: true,  // Error on extra non-empty columns
  headers: ['name', 'age']
});
```

When enabled:
- Rows with extra non-empty columns trigger a `PARSE_ERROR`
- Trailing empty or whitespace-only columns are tolerated
- Requires headers to be defined (either from first row or via options)

## Test plan

- [x] 18 new unit tests covering both features
- [x] Tests for edge cases: extra columns, fewer columns, empty trailing columns, quoted values
- [x] All 82 unit tests pass
- [x] Linting passes
- [x] Build succeeds
- [ ] Browser tests (requires Playwright installation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)